### PR TITLE
Add support for Rails 5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+== 0.5.15
+* BREAKING CHANGE: Replace deprecated before_filter to before_action for rails 5+ support
+
+== 0.5.14
+* Import active_model/serializers/xml since it's been move to external gem
+
 == 0.5.2
 * BREAKING CHANGE: removed `collection` method in resource. please always use `read_all`
 * Added simple authorization helper

--- a/cyrax.gemspec
+++ b/cyrax.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport"
   spec.add_dependency "activemodel"
+  spec.add_dependency "active_model_serializers"
+  spec.add_dependency "activemodel-serializers-xml"
   spec.add_dependency "has_active_logger"
   spec.add_dependency "multi_json"
 

--- a/example/app/controllers/api/products_controller.rb
+++ b/example/app/controllers/api/products_controller.rb
@@ -1,5 +1,5 @@
 class Api::ProductsController < ApplicationController
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
   respond_to :json
 
   def index

--- a/example/app/controllers/products_controller.rb
+++ b/example/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
   respond_to :html
 
   def index

--- a/lib/cyrax/decorator.rb
+++ b/lib/cyrax/decorator.rb
@@ -1,4 +1,5 @@
 require 'active_model'
+require 'active_model/serializers/xml'
 class Cyrax::Decorator < Cyrax::Wrapper
   include ActiveModel::Serialization
   include ActiveModel::Serializers::JSON

--- a/lib/cyrax/version.rb
+++ b/lib/cyrax/version.rb
@@ -1,3 +1,3 @@
 module Cyrax
-  VERSION = "0.5.13"
+  VERSION = "0.5.15"
 end


### PR DESCRIPTION
add activemodel-serializers-xml gem to dependency

bump version

require activemodel serializer xml

rename before_filter to before_action and bump version

update changelog